### PR TITLE
Fix Vercel config: replace routes with rewrites

### DIFF
--- a/mobile-app-configs/vercel.json
+++ b/mobile-app-configs/vercel.json
@@ -10,10 +10,10 @@
       }
     }
   ],
-  "routes": [
+  "rewrites": [
     {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ],
   "headers": [

--- a/web-app-configs/vercel.json
+++ b/web-app-configs/vercel.json
@@ -10,10 +10,10 @@
       }
     }
   ],
-  "routes": [
+  "rewrites": [
     {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Purpose
The user was experiencing deployment issues with their mobile app on Vercel due to configuration conflicts. They encountered an error stating that `routes` cannot be present when other routing configurations like `rewrites`, `redirects`, `headers`, `cleanUrls` or `trailingSlash` are used. The goal was to resolve this deployment configuration issue without changing any styling.

## Code changes
- **Updated Vercel configuration files**: Replaced deprecated `routes` configuration with `rewrites` in both `mobile-app-configs/vercel.json` and `web-app-configs/vercel.json`
- **Property name changes**: 
  - Changed `"routes"` to `"rewrites"`
  - Changed `"src"` to `"source"` 
  - Changed `"dest"` to `"destination"`
- **Maintained functionality**: The routing behavior remains the same - all requests are still directed to `/index.html` for SPA routing

This resolves the Vercel deployment conflict while preserving the existing routing functionality.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6ed6f632e2a64e80bc144ccd8413499b/neon-den)

👀 [Preview Link](https://6ed6f632e2a64e80bc144ccd8413499b-neon-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6ed6f632e2a64e80bc144ccd8413499b</projectId>-->
<!--<branchName>neon-den</branchName>-->